### PR TITLE
Simpler realistic function

### DIFF
--- a/tests/testthat/test-ts_generator.R
+++ b/tests/testthat/test-ts_generator.R
@@ -48,12 +48,8 @@ test_that("Realistic decay (stochastic)", {
   thalf <- 1
 
   sd_expected <- 0.7 # Desired sd for the generated time series
-  sigma <- sd_expected * sqrt(2 * log(2) / thalf)
-  # The assignation above uses the relationship between infinitesimal (sigma) and asymptotic (measured) standard deviation.
-  # i.e: such a sigma creates a time series with sd_expected (provided t_0 = 0 t_end = inf)
-  # More info: https://math.stackexchange.com/questions/2558659/expectation-and-variance-of-stochastic-differential-equations
 
-  ys_r <- realistic(ts, offset = offset, pert = pert, tpert = tpert, thalf = thalf, noise = 0, sigma = sigma)
+  ys_r <- realistic(ts, offset = offset, pert = pert, tpert = tpert, thalf = thalf, noise = sd_expected)
   sd_measured <- sd(ys_r)
 
   expect_equal(sd_measured, sd_expected, tolerance = 0.1)

--- a/vignettes/plotting_decays.Rmd
+++ b/vignettes/plotting_decays.Rmd
@@ -34,17 +34,10 @@ tpert <- 15
 thalf <- 3
 noise <- 0.1
 
-# The 'realistic' time series contains an extra parameter, controlling the 'dynamic' noise
-# Choosing noise = 0 and sigma defined as below, we have the same standard deviations for the
-# three time series (if they are long enough).
-#
-# Reference: https://math.stackexchange.com/questions/2558659/expectation-and-variance-of-stochastic-differential-equations
-sigma <- noise * sqrt(2 * log(2) / thalf)
-
 # Generate the time series
 ys_p <- piecewise(ts, offset, pert, tpert, thalf, noise)
 ys_e <- exponential(ts, offset, pert, tpert, thalf, noise)
-ys_r <- realistic(ts, offset, pert, tpert, thalf, 0.00, sigma)
+ys_r <- realistic(ts, offset, pert, tpert, thalf, noise)
 ```
 
 ### Plots


### PR DESCRIPTION
The `realistic` function is now way easier to use. The `sigma` parameter has been eliminated, and all the noise is controlled by the `noise` parameter. The price paid was killing the built-in additive noise functionality (representing measurement errors).

This change is potentially not backwards-compatible (only if the function `realistic` was used before).

Links with issue #27, and potentially closes it.